### PR TITLE
Add live polling to counter

### DIFF
--- a/counter.html
+++ b/counter.html
@@ -117,11 +117,46 @@
     const btn      = document.getElementById('btn');
     const statusEl = document.getElementById('status');
 
+    let pollTimer = null;
+    let lastCount = null;
+
     function setStatus(msg, isError = false) {
       statusEl.textContent = msg;
       statusEl.className   = isError ? 'error' : '';
     }
 
+    // ─── Polling ───────────────────────────────────────────────────────────────
+    function startPolling() {
+      stopPolling();
+      pollTimer = setInterval(pollCounter, 5000);
+    }
+
+    function stopPolling() {
+      if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    }
+
+    async function pollCounter() {
+      try {
+        const res = await fetch(WORKER_URL);
+        if (!res.ok) return;
+        const { count } = await res.json();
+        if (count !== lastCount) {
+          countEl.textContent = count.toLocaleString();
+          lastCount = count;
+        }
+      } catch {} // silent — next poll will retry
+    }
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        pollCounter();
+        startPolling();
+      }
+    });
+
+    // ─── Core ──────────────────────────────────────────────────────────────────
     async function fetchCounter() {
       countEl.className   = 'loading';
       countEl.textContent = '…';
@@ -134,8 +169,10 @@
         const { count } = await res.json();
         countEl.textContent = count.toLocaleString();
         countEl.className   = '';
+        lastCount = count;
         btn.disabled = (WORKER_URL === 'REPLACE_WITH_YOUR_WORKER_URL');
         if (btn.disabled) setStatus('Worker URL not configured.', true);
+        else startPolling();
       } catch (err) {
         setStatus(`Failed to load counter: ${err.message}`, true);
         countEl.textContent = '?';
@@ -145,6 +182,7 @@
 
     async function increment() {
       btn.disabled = true;
+      stopPolling();
       setStatus('Saving…');
 
       try {
@@ -152,12 +190,14 @@
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const { count } = await res.json();
         countEl.textContent = count.toLocaleString();
+        lastCount = count;
         setStatus('');
         btn.disabled = false;
       } catch (err) {
         setStatus(`Error: ${err.message}`, true);
         btn.disabled = false;
       }
+      startPolling();
     }
 
     btn.addEventListener('click', increment);


### PR DESCRIPTION
## Summary
- Polls the counter API every 5 seconds so browsers see each other's increments without manual refresh
- Pauses polling when the tab is hidden, resumes immediately on focus
- Stops polling during increment to avoid race conditions

## Test plan
- [ ] Open counter in two browser windows side by side
- [ ] Click +1 in one — the other should update within ~5 seconds
- [ ] Background a tab, verify polling stops (Network tab)
- [ ] Foreground it, verify it polls immediately and resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)