### PR TITLE
Add composer timeline

### DIFF
--- a/composers/index.html
+++ b/composers/index.html
@@ -16,7 +16,7 @@
     --ink-faint: #8a8170;
     --rule: #c9bea7;
     --baroque: #6b1d2c;
-    --classical: #8a6d1c;
+    --classical: #7a6015;
     --romantic: #1f4f3c;
     --late-rom: #2a3a6b;
     --modern: #4a2a5c;
@@ -527,12 +527,16 @@
     --ink-soft: #c0a880;
     --ink-faint: #6a5a40;
     --rule: #352c20;
-    --baroque: #d44060;
+    --baroque: #c01c38;
     --classical: #c8982a;
-    --romantic: #38886a;
-    --late-rom: #4868b8;
-    --modern: #885ab0;
+    --romantic: #206848;
+    --late-rom: #3858a8;
+    --modern: #7848a0;
   }
+  /* Inside names: use cream text in dark mode (bars are dark enough for 4.5:1),
+     except classical whose bar is light — keep dark text there. */
+  html.dark .composer-name.inside { color: var(--ink); }
+  html.dark .row[data-era="classical"] .composer-name.inside { color: var(--bg); }
   html.dark body {
     background-image:
       radial-gradient(circle at 20% 30%, rgba(200, 152, 42, 0.07) 0%, transparent 50%),

--- a/composers/index.html
+++ b/composers/index.html
@@ -113,6 +113,7 @@
     margin-bottom: 28px;
     padding: 14px 0;
     border-bottom: 1px dashed var(--rule);
+    align-items: center;
   }
 
   .legend-item {
@@ -129,6 +130,7 @@
     width: 16px;
     height: 10px;
     border-radius: 1px;
+    transition: box-shadow 0.15s ease;
   }
   .swatch.baroque   { background: var(--baroque); }
   .swatch.classical { background: var(--classical); }
@@ -143,7 +145,13 @@
     padding-bottom: 16px;
     margin: 0 -8px;
     padding: 0 8px 16px;
+    /* 7. Styled scrollbar */
+    scrollbar-width: thin;
+    scrollbar-color: var(--rule) var(--bg-2);
   }
+  .timeline-wrap::-webkit-scrollbar { height: 6px; }
+  .timeline-wrap::-webkit-scrollbar-track { background: var(--bg-2); border-radius: 3px; }
+  .timeline-wrap::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 3px; }
 
   .timeline {
     position: relative;
@@ -209,7 +217,8 @@
     position: relative;
     height: 30px;
     border-bottom: 1px solid rgba(201, 190, 167, 0.4);
-    transition: background 0.18s ease;
+    transition: background 0.18s ease, opacity 0.2s ease;
+    cursor: pointer;
   }
 
   .row:hover {
@@ -266,7 +275,7 @@
     border-radius: 1px;
     z-index: 2;
     transition: transform 0.18s ease, filter 0.18s ease, opacity 0.18s ease;
-    cursor: default;
+    cursor: pointer;
   }
   .bar.baroque   { background: var(--baroque); }
   .bar.classical { background: var(--classical); }
@@ -350,6 +359,10 @@
     color: var(--ink);
     background: rgba(255, 255, 255, 0.3);
   }
+  .toggle-btn:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 3px;
+  }
   .toggle-btn .dot {
     width: 8px;
     height: 8px;
@@ -417,7 +430,7 @@
     pointer-events: none;
     opacity: 0;
     transition: opacity 0.15s ease;
-    z-index: 100;
+    z-index: 200;
     max-width: 280px;
     box-shadow: 0 8px 24px rgba(0,0,0,0.18);
   }
@@ -466,6 +479,7 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 12px;
+    align-items: center;
   }
 
   /* Page load animation */
@@ -482,6 +496,295 @@
     .page { padding: 24px 16px 40px; }
     .header { flex-direction: column; align-items: flex-start; }
     .subtitle { text-align: left; }
+  }
+
+  /* ===== ADDITIONS ===== */
+
+  /* 4. Paper grain texture */
+  body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 150;
+    opacity: 0.038;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 200px 200px;
+  }
+
+  /* 6. Living composer pulse */
+  @keyframes breathe {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.68; }
+  }
+
+  /* 5. Candlelight dark mode */
+  html.dark {
+    --bg: #100d08;
+    --bg-2: #1c1710;
+    --ink: #f0e6cc;
+    --ink-soft: #c0a880;
+    --ink-faint: #6a5a40;
+    --rule: #352c20;
+    --baroque: #d44060;
+    --classical: #c8982a;
+    --romantic: #38886a;
+    --late-rom: #4868b8;
+    --modern: #885ab0;
+  }
+  html.dark body {
+    background-image:
+      radial-gradient(circle at 20% 30%, rgba(200, 152, 42, 0.07) 0%, transparent 50%),
+      radial-gradient(circle at 80% 70%, rgba(56, 136, 106, 0.07) 0%, transparent 50%);
+  }
+  html.dark .row:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+  html.dark .connections path {
+    stroke: #b8845a;
+    filter: drop-shadow(0 0 3px rgba(184, 132, 90, 0.4));
+    opacity: 0.45;
+  }
+  html.dark .connections path:hover,
+  html.dark .connections path.active {
+    opacity: 0.95;
+    filter: drop-shadow(0 0 6px rgba(184, 132, 90, 0.7));
+  }
+  html.dark .connections circle {
+    fill: #b8845a;
+  }
+  html.dark .connections path.conn-focused {
+    stroke: #d4a070;
+    filter: drop-shadow(0 0 5px rgba(212, 160, 112, 0.8));
+    opacity: 0.95;
+  }
+
+  /* 3. Era filter */
+  .legend-item[data-era] {
+    cursor: pointer;
+    user-select: none;
+    border-radius: 4px;
+    padding: 3px 6px;
+    margin: -3px -6px;
+    transition: opacity 0.15s ease, background 0.15s ease;
+  }
+  .legend-item[data-era]:hover {
+    background: rgba(128, 128, 128, 0.09);
+  }
+  .legend-item[data-era].era-active .swatch {
+    box-shadow: 0 0 0 2px currentColor;
+  }
+  .legend-item[data-era].era-active {
+    color: var(--ink);
+  }
+  .rows.era-filtered .row {
+    opacity: 0.12;
+  }
+  .rows.era-filtered .row.era-match {
+    opacity: 1;
+  }
+
+  /* 8. Keyboard navigation */
+  .row:focus-visible {
+    outline: 2px solid var(--ink-soft);
+    outline-offset: -2px;
+    border-radius: 1px;
+  }
+
+  /* 2. Composer focus mode */
+  .rows.has-focus .row {
+    opacity: 0.12;
+  }
+  .rows.has-focus .row.focused {
+    opacity: 1;
+  }
+  .rows.has-focus .row.focused:hover {
+    background: rgba(255, 255, 255, 0.4);
+  }
+  .rows.has-focus .connections path {
+    opacity: 0.06;
+  }
+  .rows.has-focus .connections path.conn-focused {
+    opacity: 0.95;
+    stroke-width: 2;
+  }
+  .rows.has-focus .connections circle {
+    opacity: 0.1;
+  }
+  .rows.has-focus .connections circle.conn-focused-ep {
+    opacity: 1;
+    r: 3;
+  }
+
+  /* Detail panel */
+  .detail-panel {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--bg);
+    border-top: 1.5px solid var(--ink);
+    padding: 20px 32px 28px;
+    z-index: 180;
+    transform: translateY(100%);
+    transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+    max-height: 55vh;
+    overflow-y: auto;
+    box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.12);
+    scrollbar-width: thin;
+    scrollbar-color: var(--rule) transparent;
+  }
+  .detail-panel.show {
+    transform: translateY(0);
+  }
+  .detail-panel-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 20px;
+    align-items: start;
+  }
+  .detail-name {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: clamp(26px, 4vw, 46px);
+    font-weight: 500;
+    font-style: italic;
+    line-height: 1;
+    margin-bottom: 6px;
+  }
+  .detail-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 10px;
+  }
+  .detail-works {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 16px;
+    font-style: italic;
+    color: var(--ink-soft);
+    margin-bottom: 16px;
+    line-height: 1.5;
+  }
+  .detail-connections-label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 8px;
+  }
+  .detail-connections {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .detail-conn-item {
+    padding: 8px 12px;
+    border-left: 2px solid var(--rule);
+    background: rgba(128, 128, 128, 0.04);
+  }
+  .detail-conn-who {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 3px;
+    color: var(--ink);
+  }
+  .detail-conn-note {
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
+    color: var(--ink-soft);
+    line-height: 1.55;
+  }
+  .detail-close {
+    background: none;
+    border: 1px solid var(--rule);
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--ink-soft);
+    font-size: 18px;
+    line-height: 1;
+    transition: border-color 0.15s, color 0.15s;
+    flex-shrink: 0;
+  }
+  .detail-close:hover {
+    border-color: var(--ink);
+    color: var(--ink);
+  }
+  .detail-close:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 3px;
+  }
+
+  /* 1. Year cursor */
+  .year-cursor {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--ink);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    z-index: 10;
+  }
+  .timeline-wrap.cursor-active .year-cursor {
+    opacity: 0.6;
+  }
+  .year-cursor-label {
+    position: absolute;
+    top: 6px;
+    left: 5px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    color: var(--ink);
+    white-space: nowrap;
+    background: var(--bg);
+    padding: 1px 4px;
+    border-radius: 2px;
+    box-shadow: 0 1px 6px rgba(0,0,0,0.08);
+  }
+  .year-cursor-badge {
+    position: absolute;
+    bottom: 8px;
+    left: 5px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    color: var(--bg);
+    background: var(--ink);
+    padding: 2px 7px;
+    border-radius: 2px;
+    white-space: nowrap;
+    opacity: 0.88;
+  }
+  .year-cursor.flip .year-cursor-label,
+  .year-cursor.flip .year-cursor-badge {
+    left: auto;
+    right: 5px;
+  }
+
+  /* Year cursor row states — override era/focus opacity on hover */
+  .timeline-wrap.cursor-active .rows .row {
+    opacity: 0.18 !important;
+    transition: opacity 0.08s ease;
+  }
+  .timeline-wrap.cursor-active .rows .row.cursor-alive {
+    opacity: 0.55 !important;
+  }
+  .timeline-wrap.cursor-active .rows .row.cursor-composing {
+    opacity: 1 !important;
   }
 </style>
 </head>
@@ -504,11 +807,11 @@
   </div>
 
   <div class="legend">
-    <div class="legend-item"><span class="swatch baroque"></span>Baroque · 1600–1750</div>
-    <div class="legend-item"><span class="swatch classical"></span>Classical · 1750–1820</div>
-    <div class="legend-item"><span class="swatch romantic"></span>Romantic · 1820–1880</div>
-    <div class="legend-item"><span class="swatch late-rom"></span>Late Romantic · 1880–1910</div>
-    <div class="legend-item"><span class="swatch modern"></span>20th Century · 1910–</div>
+    <div class="legend-item" data-era="baroque"><span class="swatch baroque"></span>Baroque · 1600–1750</div>
+    <div class="legend-item" data-era="classical"><span class="swatch classical"></span>Classical · 1750–1820</div>
+    <div class="legend-item" data-era="romantic"><span class="swatch romantic"></span>Romantic · 1820–1880</div>
+    <div class="legend-item" data-era="late-rom"><span class="swatch late-rom"></span>Late Romantic · 1880–1910</div>
+    <div class="legend-item" data-era="modern"><span class="swatch modern"></span>20th Century · 1910–</div>
     <div class="legend-item" style="margin-left:auto">
       <svg width="22" height="10" style="overflow:visible">
         <path d="M 1 5 Q 11 -3 21 5" fill="none" stroke="#2a1f12" stroke-width="1" opacity="0.6"/>
@@ -525,6 +828,10 @@
       <span class="dot"></span>
       <span>Connections</span>
     </button>
+    <button class="toggle-btn" id="darkToggle" aria-pressed="false" type="button">
+      <span class="dot"></span>
+      <span>Night</span>
+    </button>
   </div>
 
   <div class="timeline-wrap">
@@ -533,10 +840,13 @@
 
   <div class="footer">
     <span>Sources: standard biographical records</span>
+    <span>Click any composer to focus · Click era swatches to filter</span>
     <span>Drawn in the year 2026</span>
   </div>
 
 </div>
+
+<div class="detail-panel" id="detailPanel"></div>
 
 <div class="tooltip" id="tooltip"></div>
 
@@ -549,9 +859,9 @@
     { name: 'Johann Sebastian Bach',    surname: 'Bach',          birth: 1685, death: 1750, era: 'baroque',   hours: 110, firstWork: 1700, lastWork: 1750, works: 'Mass in B minor; St. Matthew Passion; Brandenburg Concertos' },
     { name: 'George Frideric Handel',   surname: 'Handel',        birth: 1685, death: 1759, era: 'baroque',   hours: 90,  firstWork: 1702, lastWork: 1757, works: 'Messiah; Water Music; Music for the Royal Fireworks' },
     { name: 'Joseph Haydn',             surname: 'Haydn',         birth: 1732, death: 1809, era: 'classical', hours: 95,  firstWork: 1750, lastWork: 1803, works: '104 symphonies; The Creation; String Quartets Op. 76' },
-    { name: 'Wolfgang Amadeus Mozart',  surname: 'Mozart',        birth: 1756, death: 1791, era: 'classical', hours: 70,  firstWork: 1761, lastWork: 1791, works: 'Don Giovanni; Requiem; Symphony No. 41 “Jupiter”' },
+    { name: 'Wolfgang Amadeus Mozart',  surname: 'Mozart',        birth: 1756, death: 1791, era: 'classical', hours: 70,  firstWork: 1761, lastWork: 1791, works: 'Don Giovanni; Requiem; Symphony No. 41 "Jupiter"' },
     { name: 'Ludwig van Beethoven',     surname: 'Beethoven',     birth: 1770, death: 1827, era: 'classical', hours: 40,  firstWork: 1782, lastWork: 1826, works: '9 symphonies; Missa Solemnis; late string quartets' },
-    { name: 'Franz Schubert',           surname: 'Schubert',      birth: 1797, death: 1828, era: 'romantic',  hours: 50,  firstWork: 1810, lastWork: 1828, works: 'Winterreise; Symphony No. 8 “Unfinished”; String Quintet' },
+    { name: 'Franz Schubert',           surname: 'Schubert',      birth: 1797, death: 1828, era: 'romantic',  hours: 50,  firstWork: 1810, lastWork: 1828, works: 'Winterreise; Symphony No. 8 "Unfinished"; String Quintet' },
     { name: 'Hector Berlioz',           surname: 'Berlioz',       birth: 1803, death: 1869, era: 'romantic',  hours: 25,  firstWork: 1818, lastWork: 1862, works: 'Symphonie fantastique; Grande messe des morts; Les Troyens' },
     { name: 'Felix Mendelssohn',        surname: 'Mendelssohn',   birth: 1809, death: 1847, era: 'romantic',  hours: 30,  firstWork: 1820, lastWork: 1847, works: 'Elijah; Violin Concerto in E minor; Italian Symphony' },
     { name: 'Frédéric Chopin',          surname: 'Chopin',        birth: 1810, death: 1849, era: 'romantic',  hours: 12,  firstWork: 1817, lastWork: 1849, works: 'Ballades; Nocturnes; Piano Concertos Nos. 1 & 2' },
@@ -560,10 +870,10 @@
     { name: 'Richard Wagner',           surname: 'Wagner',        birth: 1813, death: 1883, era: 'romantic',  hours: 55,  firstWork: 1832, lastWork: 1882, works: 'Der Ring des Nibelungen; Tristan und Isolde; Parsifal' },
     { name: 'Giuseppe Verdi',           surname: 'Verdi',         birth: 1813, death: 1901, era: 'romantic',  hours: 70,  firstWork: 1839, lastWork: 1898, works: 'La traviata; Aida; Requiem; Otello' },
     { name: 'Johannes Brahms',          surname: 'Brahms',        birth: 1833, death: 1897, era: 'romantic',  hours: 30,  firstWork: 1851, lastWork: 1896, works: 'Ein deutsches Requiem; 4 symphonies; Violin Concerto' },
-    { name: 'Pyotr Ilyich Tchaikovsky', surname: 'Tchaikovsky',   birth: 1840, death: 1893, era: 'romantic',  hours: 40,  firstWork: 1864, lastWork: 1893, works: 'Swan Lake; 1812 Overture; Symphony No. 6 “Pathétique”' },
-    { name: 'Antonín Dvořák',           surname: 'Dvořák',        birth: 1841, death: 1904, era: 'romantic',  hours: 30,  firstWork: 1862, lastWork: 1904, works: 'Symphony No. 9 “New World”; Cello Concerto; Stabat Mater' },
+    { name: 'Pyotr Ilyich Tchaikovsky', surname: 'Tchaikovsky',   birth: 1840, death: 1893, era: 'romantic',  hours: 40,  firstWork: 1864, lastWork: 1893, works: 'Swan Lake; 1812 Overture; Symphony No. 6 "Pathétique"' },
+    { name: 'Antonín Dvořák',           surname: 'Dvořák',        birth: 1841, death: 1904, era: 'romantic',  hours: 30,  firstWork: 1862, lastWork: 1904, works: 'Symphony No. 9 "New World"; Cello Concerto; Stabat Mater' },
     { name: 'Gabriel Fauré',             surname: 'Fauré',         birth: 1845, death: 1924, era: 'late-rom',  hours: 15,  firstWork: 1860, lastWork: 1924, works: 'Requiem; Pavane; Pelléas et Mélisande; many mélodies' },
-    { name: 'Gustav Mahler',            surname: 'Mahler',        birth: 1860, death: 1911, era: 'late-rom',  hours: 15,  firstWork: 1880, lastWork: 1910, works: 'Symphony No. 2 “Resurrection”; Das Lied von der Erde; Symphony No. 9' },
+    { name: 'Gustav Mahler',            surname: 'Mahler',        birth: 1860, death: 1911, era: 'late-rom',  hours: 15,  firstWork: 1880, lastWork: 1910, works: 'Symphony No. 2 "Resurrection"; Das Lied von der Erde; Symphony No. 9' },
     { name: 'Claude Debussy',           surname: 'Debussy',       birth: 1862, death: 1918, era: 'late-rom',  hours: 15,  firstWork: 1880, lastWork: 1917, works: 'Prélude à l’après-midi d’un faune; La mer; Pelléas et Mélisande' },
     { name: 'Richard Strauss',          surname: 'R. Strauss',    birth: 1864, death: 1949, era: 'late-rom',  hours: 55,  firstWork: 1880, lastWork: 1948, works: 'Also sprach Zarathustra; Der Rosenkavalier; Four Last Songs' },
     { name: 'Jean Sibelius',            surname: 'Sibelius',      birth: 1865, death: 1957, era: 'late-rom',  hours: 80,  firstWork: 1875, lastWork: 1929, works: 'Finlandia; Violin Concerto; 7 symphonies' },
@@ -603,7 +913,6 @@
   axis.className = 'axis';
 
   // Era bands inside axis area extending into rows
-  // We add them as absolutely positioned overlays inside timeline (behind rows)
   const bandsContainer = document.createElement('div');
   bandsContainer.style.position = 'absolute';
   bandsContainer.style.left = '0';
@@ -653,7 +962,7 @@
   rows.style.position = 'relative';
   rows.appendChild(bandsContainer);
 
-  // Bar height encodes total composed output (square-root scale to compress the range)
+  // Bar height encodes total composed output (square-root scale)
   function barHeight(hours) {
     const minH = 5;
     const maxH = 22;
@@ -661,6 +970,9 @@
     const t = Math.sqrt(Math.min(hours, maxHours) / maxHours);
     return minH + (maxH - minH) * t;
   }
+
+  // Focus mode state (declared before forEach so closures can reference it)
+  let focusedIdx = -1;
 
   composers.forEach((c, i) => {
     const row = document.createElement('div');
@@ -694,19 +1006,22 @@
     activeBar.style.animationDelay = (i * 35 + 120) + 'ms';
     row.appendChild(activeBar);
 
-    // Composer name — placement uses the lifespan bar geometry
+    // 6. Breathe animation for living active bar — starts after drawBar finishes
+    if (isStillActive) {
+      const drawFinishMs = i * 35 + 120 + 950;
+      setTimeout(() => {
+        activeBar.style.animation = 'breathe 3.5s ease-in-out infinite';
+        activeBar.style.animationDelay = '';
+      }, drawFinishMs);
+    }
+
+    // Composer name placement
     const leftPct = lifeLeft;
     const widthPct = lifeWidth;
 
-    // Composer name — placed cleverly: if bar is wide enough, inside; if at right edge, before the bar; otherwise after
     const name = document.createElement('div');
     name.className = 'composer-name';
 
-    // Decide placement
-    // Approximate pixel width: depends on viewport. Use percentage logic:
-    // If bar width > 14% of timeline → name inside bar (left-padded)
-    // Else if bar starts in right half (>50%) → name to the LEFT of bar
-    // Else → name to the RIGHT of bar
     if (widthPct > 14) {
       name.classList.add('inside');
       name.style.left = `calc(${leftPct}% + 8px)`;
@@ -722,30 +1037,27 @@
     }
     row.appendChild(name);
 
-    // Year label — birth year before bar (small, faint)
+    // Year labels
     const years = document.createElement('div');
     years.className = 'years';
     years.style.right = `calc(${100 - leftPct}% + 6px)`;
     years.textContent = c.birth;
     row.appendChild(years);
 
-    // Death year after bar
     const yearsRight = document.createElement('div');
     yearsRight.className = 'years';
     yearsRight.style.left = `calc(${leftPct + widthPct}% + 6px)`;
     yearsRight.textContent = isLiving ? '' : c.death;
-    // Don't show death year if name is to the right (would collide)
     if (name.classList.contains('outside-right')) {
       yearsRight.style.display = 'none';
     }
     row.appendChild(yearsRight);
 
-    // Hide birth-year label if name is to the left of bar (would collide)
     if (name.classList.contains('outside-left')) {
       years.style.display = 'none';
     }
 
-    // Hover tooltip via dataset
+    // Dataset for tooltip
     row.dataset.name = c.name;
     row.dataset.birth = c.birth;
     row.dataset.death = isLiving ? 'present' : c.death;
@@ -756,6 +1068,18 @@
     row.dataset.firstWork = c.firstWork;
     row.dataset.lastWork = isStillActive ? 'present' : c.lastWork;
     row.dataset.silentYears = !isStillActive ? (effectiveDeath - c.lastWork) : 0;
+    row.dataset.idx = i;
+
+    // 8. Keyboard navigation
+    row.setAttribute('tabindex', '0');
+    row.setAttribute('role', 'button');
+    row.setAttribute('aria-label', `${c.name}, ${c.birth}–${isLiving ? 'present' : c.death}, ${c.era} era`);
+    row.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); focusComposer(i); }
+    });
+
+    // 2. Focus mode — click to focus
+    row.addEventListener('click', () => focusComposer(i));
 
     rows.appendChild(row);
   });
@@ -763,7 +1087,6 @@
   tl.appendChild(rows);
 
   // ===== Connections =====
-  // from/to are indices into the composers array (0-based)
   const connections = [
     { from: 3,  to: 4,  year: 1785, posthumous: false, note: 'Haydn and Mozart became close friends in Vienna in the 1780s. Mozart dedicated his six "Haydn" Quartets to him; Haydn told Leopold Mozart his son was "the greatest composer known to me."' },
     { from: 3,  to: 5,  year: 1793, posthumous: false, note: 'Beethoven studied counterpoint with Haydn in Vienna, 1792–94. The lessons were uneven (Beethoven secretly took extra lessons with Schenk), but the connection is direct.' },
@@ -801,7 +1124,6 @@
     svg.setAttribute('width', W);
     svg.setAttribute('height', H);
 
-    // Clear
     while (svg.firstChild) svg.removeChild(svg.firstChild);
 
     function xFromYear(year) {
@@ -817,7 +1139,6 @@
       const y2 = yFromIndex(conn.to);
       const dy = Math.abs(y2 - y1);
 
-      // Curve bulges to the right; bulge scales with vertical distance
       const bulge = Math.min(70, 12 + dy * 0.35);
 
       const path = document.createElementNS(svgNS, 'path');
@@ -832,7 +1153,6 @@
       path.dataset.fromIdx = conn.from;
       path.dataset.toIdx = conn.to;
 
-      // Endpoint dots
       const c1 = document.createElementNS(svgNS, 'circle');
       c1.setAttribute('cx', x);
       c1.setAttribute('cy', y1);
@@ -851,8 +1171,9 @@
       svg.appendChild(c1);
       svg.appendChild(c2);
 
-      // Hover handling on the path
       path.addEventListener('mousemove', (e) => {
+        // 2. Focus mode guard
+        if (focusedIdx !== -1 && !path.classList.contains('conn-focused')) return;
         path.classList.add('active');
         c1.classList.add('active');
         c2.classList.add('active');
@@ -872,19 +1193,20 @@
       });
     });
 
-    // Trigger draw-in animation on first render
     if (!svg.classList.contains('animate')) {
       svg.classList.add('animate');
     }
+
+    // Re-apply focus state after redraw
+    if (focusedIdx !== -1) updateFocusedConnections();
   }
 
-  // Initial draw + redraw on resize
   requestAnimationFrame(drawConnections);
   let resizeTimer;
   window.addEventListener('resize', () => {
     clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => {
-      svg.classList.remove('animate'); // skip animation on resize
+      svg.classList.remove('animate');
       drawConnections();
     }, 80);
   });
@@ -900,7 +1222,7 @@
     tooltip.style.top = y + 'px';
   }
 
-  // Toggle handler for connections visibility
+  // Toggle connections visibility
   const toggleBtn = document.getElementById('toggleConnections');
   toggleBtn.addEventListener('click', () => {
     const isPressed = toggleBtn.getAttribute('aria-pressed') === 'true';
@@ -909,7 +1231,172 @@
     svg.classList.toggle('hidden', !next);
   });
 
-  // ===== End connections =====
+  // 5. Dark mode toggle
+  const darkToggle = document.getElementById('darkToggle');
+  const htmlEl = document.documentElement;
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    htmlEl.classList.add('dark');
+    darkToggle.setAttribute('aria-pressed', 'true');
+  }
+  darkToggle.addEventListener('click', () => {
+    const isDark = htmlEl.classList.toggle('dark');
+    darkToggle.setAttribute('aria-pressed', String(isDark));
+  });
+
+  // 3. Era filter
+  const activeEras = new Set();
+  document.querySelectorAll('.legend-item[data-era]').forEach(item => {
+    item.addEventListener('click', () => {
+      const era = item.dataset.era;
+      if (activeEras.has(era)) {
+        activeEras.delete(era);
+        item.classList.remove('era-active');
+      } else {
+        activeEras.add(era);
+        item.classList.add('era-active');
+      }
+      applyEraFilter();
+    });
+  });
+
+  function applyEraFilter() {
+    const rowEls = document.querySelectorAll('.row');
+    if (activeEras.size === 0) {
+      rows.classList.remove('era-filtered');
+      rowEls.forEach(row => row.classList.remove('era-match'));
+    } else {
+      rows.classList.add('era-filtered');
+      rowEls.forEach(row => {
+        row.classList.toggle('era-match', activeEras.has(row.dataset.era));
+      });
+    }
+  }
+
+  // 2. Focus mode functions (hoisted via function declarations)
+  function focusComposer(idx) {
+    if (focusedIdx === idx) { clearFocus(); return; }
+    focusedIdx = idx;
+    document.querySelectorAll('.row').forEach((row, i) => {
+      row.classList.toggle('focused', i === idx);
+    });
+    rows.classList.add('has-focus');
+    updateFocusedConnections();
+    showDetailPanel(idx);
+  }
+
+  function clearFocus() {
+    focusedIdx = -1;
+    document.querySelectorAll('.row').forEach(row => row.classList.remove('focused'));
+    rows.classList.remove('has-focus');
+    updateFocusedConnections();
+    document.getElementById('detailPanel').classList.remove('show');
+  }
+
+  function updateFocusedConnections() {
+    svg.querySelectorAll('path').forEach(path => {
+      const isFocused = focusedIdx !== -1 &&
+        (parseInt(path.dataset.fromIdx) === focusedIdx || parseInt(path.dataset.toIdx) === focusedIdx);
+      path.classList.toggle('conn-focused', isFocused);
+    });
+    svg.querySelectorAll('circle.endpoint').forEach(circle => {
+      if (focusedIdx === -1) { circle.classList.remove('conn-focused-ep'); return; }
+      const connIdx = parseInt(circle.dataset.connIdx);
+      const conn = connections[connIdx];
+      circle.classList.toggle('conn-focused-ep', conn.from === focusedIdx || conn.to === focusedIdx);
+    });
+  }
+
+  function showDetailPanel(idx) {
+    const c = composers[idx];
+    const panel = document.getElementById('detailPanel');
+    const eraLabel = { baroque: 'Baroque', classical: 'Classical', romantic: 'Romantic', 'late-rom': 'Late Romantic', modern: '20th Century' }[c.era];
+    const isLiving = c.death === null;
+    const isStillActive = c.lastWork === null;
+
+    const composerConns = connections.filter(conn => conn.from === idx || conn.to === idx);
+    let connsHtml = '';
+    if (composerConns.length) {
+      const items = composerConns.map(conn => {
+        const isFrom = conn.from === idx;
+        const other = composers[isFrom ? conn.to : conn.from];
+        const arrow = isFrom ? '→' : '←';
+        return `<div class="detail-conn-item">
+          <div class="detail-conn-who">${arrow} ${other.name} &middot; ${conn.year} &middot; ${conn.posthumous ? 'Influence' : 'Direct contact'}</div>
+          <div class="detail-conn-note">${conn.note}</div>
+        </div>`;
+      }).join('');
+      connsHtml = `<div class="detail-connections-label">Connections</div><div class="detail-connections">${items}</div>`;
+    }
+
+    panel.innerHTML = `
+      <div class="detail-panel-inner">
+        <div>
+          <div class="detail-name">${c.name}</div>
+          <div class="detail-meta">${c.birth} &ndash; ${isLiving ? 'present' : c.death} &middot; ${eraLabel} &middot; ~${c.hours} hrs of music &middot; Active ${c.firstWork}&ndash;${isStillActive ? 'present' : c.lastWork}</div>
+          <div class="detail-works">${c.works}</div>
+          ${connsHtml}
+        </div>
+        <button class="detail-close" id="detailClose" aria-label="Close">&times;</button>
+      </div>
+    `;
+    document.getElementById('detailClose').addEventListener('click', clearFocus);
+    panel.classList.add('show');
+  }
+
+  // Global keyboard handler
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') clearFocus();
+  });
+
+  // 1. Year cursor
+  const cursor = document.createElement('div');
+  cursor.className = 'year-cursor';
+  cursor.innerHTML = '<div class="year-cursor-label"></div><div class="year-cursor-badge"></div>';
+  tl.appendChild(cursor);
+
+  const wrap = tl.parentElement;
+  wrap.addEventListener('mousemove', (e) => {
+    const tlRect = tl.getBoundingClientRect();
+    const x = e.clientX - tlRect.left;
+    const totalWidth = tl.offsetWidth;
+
+    if (x < 0 || x > totalWidth) {
+      wrap.classList.remove('cursor-active');
+      return;
+    }
+
+    const year = Math.round(START_YEAR + (x / totalWidth) * yearSpan);
+    const clampedYear = Math.max(START_YEAR, Math.min(END_YEAR, year));
+    const leftPct = (x / totalWidth) * 100;
+
+    cursor.style.left = leftPct + '%';
+    cursor.classList.toggle('flip', leftPct > 70);
+    cursor.querySelector('.year-cursor-label').textContent = clampedYear;
+
+    wrap.classList.add('cursor-active');
+
+    let aliveCount = 0, composingCount = 0;
+    document.querySelectorAll('.row').forEach((row, i) => {
+      if (i >= composers.length) return;
+      const c = composers[i];
+      const alive = clampedYear >= c.birth && (c.death === null || clampedYear <= c.death);
+      const composing = alive && clampedYear >= c.firstWork && (c.lastWork === null || clampedYear <= c.lastWork);
+      row.classList.toggle('cursor-alive', alive);
+      row.classList.toggle('cursor-composing', composing);
+      if (alive) aliveCount++;
+      if (composing) composingCount++;
+    });
+
+    cursor.querySelector('.year-cursor-badge').textContent =
+      `${aliveCount} alive · ${composingCount} composing`;
+  });
+
+  wrap.addEventListener('mouseleave', () => {
+    wrap.classList.remove('cursor-active');
+    document.querySelectorAll('.row').forEach(row => {
+      row.classList.remove('cursor-alive', 'cursor-composing');
+    });
+  });
 
   // Tooltip behavior
   const tooltip = document.getElementById('tooltip');
@@ -923,6 +1410,8 @@
 
   document.querySelectorAll('.row').forEach(row => {
     row.addEventListener('mousemove', (e) => {
+      // 2. Don't show tooltip for dimmed rows in focus mode
+      if (focusedIdx !== -1 && !row.classList.contains('focused')) return;
       const age = row.dataset.age;
       const silent = parseInt(row.dataset.silentYears, 10);
       const silentNote = silent >= 5 ? ` <span class="tt-silence">— silent for ${silent} years</span>` : '';

--- a/composers/index.html
+++ b/composers/index.html
@@ -1,0 +1,950 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>A Timeline of Composers</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #f4ede0;
+    --bg-2: #ebe1cf;
+    --ink: #1a1814;
+    --ink-soft: #4a4438;
+    --ink-faint: #8a8170;
+    --rule: #c9bea7;
+    --baroque: #6b1d2c;
+    --classical: #8a6d1c;
+    --romantic: #1f4f3c;
+    --late-rom: #2a3a6b;
+    --modern: #4a2a5c;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'Inter', -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+    background-image:
+      radial-gradient(circle at 20% 30%, rgba(139, 109, 28, 0.04) 0%, transparent 50%),
+      radial-gradient(circle at 80% 70%, rgba(31, 79, 60, 0.04) 0%, transparent 50%);
+    min-height: 100vh;
+  }
+
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 48px 32px 80px;
+  }
+
+  /* Header */
+  .header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--ink);
+    padding-bottom: 18px;
+    margin-bottom: 8px;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+
+  .eyebrow {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+  }
+
+  h1 {
+    font-family: 'Cormorant Garamond', serif;
+    font-weight: 500;
+    font-style: italic;
+    font-size: clamp(36px, 6vw, 64px);
+    line-height: 1;
+    margin: 8px 0 0;
+    letter-spacing: -0.01em;
+  }
+
+  h1 .amp {
+    font-style: italic;
+    color: var(--baroque);
+  }
+
+  .subtitle {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 18px;
+    color: var(--ink-soft);
+    max-width: 380px;
+    line-height: 1.4;
+    text-align: right;
+    font-style: italic;
+  }
+
+  .meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin-bottom: 32px;
+    padding-top: 6px;
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--rule);
+    padding: 8px 0;
+  }
+
+  /* Legend */
+  .legend {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-bottom: 28px;
+    padding: 14px 0;
+    border-bottom: 1px dashed var(--rule);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    color: var(--ink-soft);
+    letter-spacing: 0.02em;
+  }
+
+  .swatch {
+    width: 16px;
+    height: 10px;
+    border-radius: 1px;
+  }
+  .swatch.baroque   { background: var(--baroque); }
+  .swatch.classical { background: var(--classical); }
+  .swatch.romantic  { background: var(--romantic); }
+  .swatch.late-rom  { background: var(--late-rom); }
+  .swatch.modern    { background: var(--modern); }
+
+  /* Timeline */
+  .timeline-wrap {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-bottom: 16px;
+    margin: 0 -8px;
+    padding: 0 8px 16px;
+  }
+
+  .timeline {
+    position: relative;
+    min-width: 920px;
+  }
+
+  .axis {
+    position: relative;
+    height: 36px;
+    border-bottom: 1px solid var(--ink);
+    margin-bottom: 4px;
+  }
+
+  .axis-tick {
+    position: absolute;
+    bottom: 0;
+    width: 1px;
+    height: 8px;
+    background: var(--ink-soft);
+    transform: translateX(-0.5px);
+  }
+  .axis-tick.major { height: 12px; }
+
+  .axis-label {
+    position: absolute;
+    bottom: 14px;
+    transform: translateX(-50%);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: var(--ink-soft);
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+  }
+
+  /* Era bands */
+  .era-band {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    opacity: 0.06;
+    pointer-events: none;
+  }
+
+  .era-label {
+    position: absolute;
+    top: 8px;
+    font-family: 'Cormorant Garamond', serif;
+    font-style: italic;
+    font-size: 13px;
+    color: var(--ink-soft);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  /* Composer rows */
+  .rows {
+    position: relative;
+  }
+
+  .row {
+    position: relative;
+    height: 30px;
+    border-bottom: 1px solid rgba(201, 190, 167, 0.4);
+    transition: background 0.18s ease;
+  }
+
+  .row:hover {
+    background: rgba(255, 255, 255, 0.4);
+  }
+
+  .row:hover .bar {
+    filter: brightness(1.05);
+    transform: translateY(-50%) scaleY(1.15);
+  }
+
+  .row:hover .composer-name {
+    color: var(--ink);
+  }
+
+  .composer-name {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--ink);
+    white-space: nowrap;
+    z-index: 3;
+    transition: color 0.15s ease;
+    text-shadow: 0 0 4px var(--bg), 0 0 4px var(--bg), 0 0 4px var(--bg);
+    padding-right: 6px;
+  }
+
+  .composer-name .surname {
+    font-weight: 600;
+  }
+
+  .composer-name.outside-left {
+    /* name placed before the bar */
+  }
+
+  .composer-name.outside-right {
+    /* name placed after the bar */
+  }
+
+  .composer-name.inside {
+    color: var(--bg);
+    text-shadow: none;
+    mix-blend-mode: normal;
+  }
+
+  .bar {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 14px;
+    border-radius: 1px;
+    z-index: 2;
+    transition: transform 0.18s ease, filter 0.18s ease, opacity 0.18s ease;
+    cursor: default;
+  }
+  .bar.baroque   { background: var(--baroque); }
+  .bar.classical { background: var(--classical); }
+  .bar.romantic  { background: var(--romantic); }
+  .bar.late-rom  { background: var(--late-rom); }
+  .bar.modern    { background: var(--modern); }
+
+  /* Lifespan bar (faded) — full birth-to-death range */
+  .bar.bar-life {
+    opacity: 0.28;
+    z-index: 2;
+  }
+  .row:hover .bar.bar-life {
+    opacity: 0.42;
+  }
+
+  /* Active composing bar (saturated) — first to last work */
+  .bar.bar-active {
+    z-index: 3;
+  }
+
+  .bar::before,
+  .bar::after {
+    display: none;
+  }
+  .bar.living {
+    -webkit-mask-image: linear-gradient(to right, #000 0%, #000 78%, transparent 100%);
+            mask-image: linear-gradient(to right, #000 0%, #000 78%, transparent 100%);
+  }
+
+  .years {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: var(--ink-faint);
+    z-index: 3;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+  }
+
+  /* Connections SVG layer */
+  .connections {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 4;
+    overflow: visible;
+    transition: opacity 0.28s ease;
+  }
+  .connections.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .connections.hidden path {
+    pointer-events: none;
+  }
+
+  /* Toggle button */
+  .toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 12px 5px 10px;
+    border: 1px solid var(--rule);
+    border-radius: 999px;
+    background: transparent;
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    color: var(--ink-soft);
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    letter-spacing: 0.02em;
+    user-select: none;
+  }
+  .toggle-btn:hover {
+    border-color: var(--ink-soft);
+    color: var(--ink);
+    background: rgba(255, 255, 255, 0.3);
+  }
+  .toggle-btn .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--ink);
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+  }
+  .toggle-btn[aria-pressed="false"] .dot {
+    background: transparent;
+    box-shadow: inset 0 0 0 1px var(--ink-faint);
+  }
+  .toggle-btn[aria-pressed="false"] {
+    color: var(--ink-faint);
+  }
+  .connections path {
+    fill: none;
+    stroke: #2a1f12;
+    stroke-width: 1;
+    opacity: 0.32;
+    pointer-events: stroke;
+    cursor: help;
+    transition: opacity 0.18s ease, stroke-width 0.18s ease;
+  }
+  .connections path.dashed {
+    stroke-dasharray: 3 3;
+  }
+  .connections path:hover,
+  .connections path.active {
+    opacity: 0.95;
+    stroke-width: 1.6;
+  }
+  .connections circle {
+    fill: #2a1f12;
+    opacity: 0.55;
+    pointer-events: none;
+    transition: opacity 0.18s ease, r 0.18s ease;
+  }
+  .connections .endpoint.active {
+    opacity: 1;
+    r: 3.2;
+  }
+
+  /* Connection line draw-in animation */
+  .connections path {
+    stroke-dashoffset: 0;
+  }
+  .connections.animate path {
+    animation: drawLine 1.2s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+  }
+  @keyframes drawLine {
+    from { stroke-dasharray: 0 1000; opacity: 0; }
+    to   { stroke-dasharray: 1000 0; opacity: 0.32; }
+  }
+
+  /* Tooltip */
+  .tooltip {
+    position: fixed;
+    background: var(--ink);
+    color: var(--bg);
+    padding: 12px 16px;
+    border-radius: 2px;
+    font-family: 'Inter', sans-serif;
+    font-size: 12px;
+    line-height: 1.5;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 100;
+    max-width: 280px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+  }
+  .tooltip.show { opacity: 1; }
+  .tooltip .tt-name {
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+  .tooltip .tt-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: var(--ink-faint);
+    letter-spacing: 0.05em;
+    margin-bottom: 6px;
+    text-transform: uppercase;
+  }
+  .tooltip .tt-stats {
+    font-family: 'Inter', sans-serif;
+    font-size: 11px;
+    color: rgba(244, 237, 224, 0.75);
+    margin-bottom: 8px;
+    letter-spacing: 0.01em;
+  }
+  .tooltip .tt-silence {
+    color: #d4a574;
+    font-style: italic;
+  }
+  .tooltip .tt-works {
+    color: rgba(244, 237, 224, 0.85);
+    font-style: italic;
+  }
+
+  /* Footer */
+  .footer {
+    margin-top: 40px;
+    padding-top: 18px;
+    border-top: 1px solid var(--rule);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: var(--ink-faint);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  /* Page load animation */
+  .row .bar {
+    transform-origin: left center;
+    animation: drawBar 0.9s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+  }
+  @keyframes drawBar {
+    from { transform: translateY(-50%) scaleX(0); opacity: 0; }
+    to   { transform: translateY(-50%) scaleX(1); opacity: 1; }
+  }
+
+  @media (max-width: 720px) {
+    .page { padding: 24px 16px 40px; }
+    .header { flex-direction: column; align-items: flex-start; }
+    .subtitle { text-align: left; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header class="header">
+    <div>
+      <div class="eyebrow">Fig. 01 — Three centuries of composition</div>
+      <h1>A Cartography <span class="amp">of</span><br/>Composers</h1>
+    </div>
+    <p class="subtitle">
+      The lives of twenty-six figures who shaped the symphonic and choral repertoire, plotted from cradle to grave.
+    </p>
+  </header>
+
+  <div class="meta">
+    <span>1678 – present · ~350 years · 29 lives · 17 ties</span>
+    <span>Bar height ≈ output volume · Saturated section ≈ active years</span>
+  </div>
+
+  <div class="legend">
+    <div class="legend-item"><span class="swatch baroque"></span>Baroque · 1600–1750</div>
+    <div class="legend-item"><span class="swatch classical"></span>Classical · 1750–1820</div>
+    <div class="legend-item"><span class="swatch romantic"></span>Romantic · 1820–1880</div>
+    <div class="legend-item"><span class="swatch late-rom"></span>Late Romantic · 1880–1910</div>
+    <div class="legend-item"><span class="swatch modern"></span>20th Century · 1910–</div>
+    <div class="legend-item" style="margin-left:auto">
+      <svg width="22" height="10" style="overflow:visible">
+        <path d="M 1 5 Q 11 -3 21 5" fill="none" stroke="#2a1f12" stroke-width="1" opacity="0.6"/>
+      </svg>
+      <span>Direct contact</span>
+    </div>
+    <div class="legend-item">
+      <svg width="22" height="10" style="overflow:visible">
+        <path d="M 1 5 Q 11 -3 21 5" fill="none" stroke="#2a1f12" stroke-width="1" opacity="0.6" stroke-dasharray="3 3"/>
+      </svg>
+      <span>Posthumous influence</span>
+    </div>
+    <button class="toggle-btn" id="toggleConnections" aria-pressed="false" type="button">
+      <span class="dot"></span>
+      <span>Connections</span>
+    </button>
+  </div>
+
+  <div class="timeline-wrap">
+    <div class="timeline" id="timeline"></div>
+  </div>
+
+  <div class="footer">
+    <span>Sources: standard biographical records</span>
+    <span>Drawn in the year 2026</span>
+  </div>
+
+</div>
+
+<div class="tooltip" id="tooltip"></div>
+
+<script>
+  // Composer data — chronological by birth year
+  // hours = approximate total composed output (rough order-of-magnitude estimates)
+  // firstWork / lastWork = first and last meaningful compositions (lastWork: null = still active)
+  const composers = [
+    { name: 'Antonio Vivaldi',          surname: 'Vivaldi',       birth: 1678, death: 1741, era: 'baroque',   hours: 85,  firstWork: 1700, lastWork: 1741, works: 'The Four Seasons; Gloria in D; ~500 concertos' },
+    { name: 'Johann Sebastian Bach',    surname: 'Bach',          birth: 1685, death: 1750, era: 'baroque',   hours: 110, firstWork: 1700, lastWork: 1750, works: 'Mass in B minor; St. Matthew Passion; Brandenburg Concertos' },
+    { name: 'George Frideric Handel',   surname: 'Handel',        birth: 1685, death: 1759, era: 'baroque',   hours: 90,  firstWork: 1702, lastWork: 1757, works: 'Messiah; Water Music; Music for the Royal Fireworks' },
+    { name: 'Joseph Haydn',             surname: 'Haydn',         birth: 1732, death: 1809, era: 'classical', hours: 95,  firstWork: 1750, lastWork: 1803, works: '104 symphonies; The Creation; String Quartets Op. 76' },
+    { name: 'Wolfgang Amadeus Mozart',  surname: 'Mozart',        birth: 1756, death: 1791, era: 'classical', hours: 70,  firstWork: 1761, lastWork: 1791, works: 'Don Giovanni; Requiem; Symphony No. 41 “Jupiter”' },
+    { name: 'Ludwig van Beethoven',     surname: 'Beethoven',     birth: 1770, death: 1827, era: 'classical', hours: 40,  firstWork: 1782, lastWork: 1826, works: '9 symphonies; Missa Solemnis; late string quartets' },
+    { name: 'Franz Schubert',           surname: 'Schubert',      birth: 1797, death: 1828, era: 'romantic',  hours: 50,  firstWork: 1810, lastWork: 1828, works: 'Winterreise; Symphony No. 8 “Unfinished”; String Quintet' },
+    { name: 'Hector Berlioz',           surname: 'Berlioz',       birth: 1803, death: 1869, era: 'romantic',  hours: 25,  firstWork: 1818, lastWork: 1862, works: 'Symphonie fantastique; Grande messe des morts; Les Troyens' },
+    { name: 'Felix Mendelssohn',        surname: 'Mendelssohn',   birth: 1809, death: 1847, era: 'romantic',  hours: 30,  firstWork: 1820, lastWork: 1847, works: 'Elijah; Violin Concerto in E minor; Italian Symphony' },
+    { name: 'Frédéric Chopin',          surname: 'Chopin',        birth: 1810, death: 1849, era: 'romantic',  hours: 12,  firstWork: 1817, lastWork: 1849, works: 'Ballades; Nocturnes; Piano Concertos Nos. 1 & 2' },
+    { name: 'Robert Schumann',          surname: 'Schumann',      birth: 1810, death: 1856, era: 'romantic',  hours: 25,  firstWork: 1828, lastWork: 1854, works: 'Dichterliebe; Piano Concerto in A minor; Symphony No. 3' },
+    { name: 'Franz Liszt',              surname: 'Liszt',         birth: 1811, death: 1886, era: 'romantic',  hours: 75,  firstWork: 1822, lastWork: 1886, works: 'Sonata in B minor; Hungarian Rhapsodies; Années de pèlerinage' },
+    { name: 'Richard Wagner',           surname: 'Wagner',        birth: 1813, death: 1883, era: 'romantic',  hours: 55,  firstWork: 1832, lastWork: 1882, works: 'Der Ring des Nibelungen; Tristan und Isolde; Parsifal' },
+    { name: 'Giuseppe Verdi',           surname: 'Verdi',         birth: 1813, death: 1901, era: 'romantic',  hours: 70,  firstWork: 1839, lastWork: 1898, works: 'La traviata; Aida; Requiem; Otello' },
+    { name: 'Johannes Brahms',          surname: 'Brahms',        birth: 1833, death: 1897, era: 'romantic',  hours: 30,  firstWork: 1851, lastWork: 1896, works: 'Ein deutsches Requiem; 4 symphonies; Violin Concerto' },
+    { name: 'Pyotr Ilyich Tchaikovsky', surname: 'Tchaikovsky',   birth: 1840, death: 1893, era: 'romantic',  hours: 40,  firstWork: 1864, lastWork: 1893, works: 'Swan Lake; 1812 Overture; Symphony No. 6 “Pathétique”' },
+    { name: 'Antonín Dvořák',           surname: 'Dvořák',        birth: 1841, death: 1904, era: 'romantic',  hours: 30,  firstWork: 1862, lastWork: 1904, works: 'Symphony No. 9 “New World”; Cello Concerto; Stabat Mater' },
+    { name: 'Gabriel Fauré',             surname: 'Fauré',         birth: 1845, death: 1924, era: 'late-rom',  hours: 15,  firstWork: 1860, lastWork: 1924, works: 'Requiem; Pavane; Pelléas et Mélisande; many mélodies' },
+    { name: 'Gustav Mahler',            surname: 'Mahler',        birth: 1860, death: 1911, era: 'late-rom',  hours: 15,  firstWork: 1880, lastWork: 1910, works: 'Symphony No. 2 “Resurrection”; Das Lied von der Erde; Symphony No. 9' },
+    { name: 'Claude Debussy',           surname: 'Debussy',       birth: 1862, death: 1918, era: 'late-rom',  hours: 15,  firstWork: 1880, lastWork: 1917, works: 'Prélude à l’après-midi d’un faune; La mer; Pelléas et Mélisande' },
+    { name: 'Richard Strauss',          surname: 'R. Strauss',    birth: 1864, death: 1949, era: 'late-rom',  hours: 55,  firstWork: 1880, lastWork: 1948, works: 'Also sprach Zarathustra; Der Rosenkavalier; Four Last Songs' },
+    { name: 'Jean Sibelius',            surname: 'Sibelius',      birth: 1865, death: 1957, era: 'late-rom',  hours: 80,  firstWork: 1875, lastWork: 1929, works: 'Finlandia; Violin Concerto; 7 symphonies' },
+    { name: 'Sergei Rachmaninoff',      surname: 'Rachmaninoff',  birth: 1873, death: 1943, era: 'late-rom',  hours: 20,  firstWork: 1890, lastWork: 1941, works: 'Piano Concerto No. 2; Rhapsody on a Theme of Paganini; All-Night Vigil' },
+    { name: 'Maurice Ravel',            surname: 'Ravel',         birth: 1875, death: 1937, era: 'late-rom',  hours: 10,  firstWork: 1893, lastWork: 1932, works: 'Boléro; Daphnis et Chloé; Piano Concerto in G' },
+    { name: 'Igor Stravinsky',          surname: 'Stravinsky',    birth: 1882, death: 1971, era: 'modern',    hours: 25,  firstWork: 1898, lastWork: 1968, works: 'The Rite of Spring; The Firebird; Symphony of Psalms' },
+    { name: 'Sergei Prokofiev',         surname: 'Prokofiev',     birth: 1891, death: 1953, era: 'modern',    hours: 35,  firstWork: 1908, lastWork: 1953, works: 'Romeo and Juliet; Peter and the Wolf; Symphony No. 5' },
+    { name: 'Dmitri Shostakovich',      surname: 'Shostakovich',  birth: 1906, death: 1975, era: 'modern',    hours: 40,  firstWork: 1919, lastWork: 1975, works: '15 symphonies; String Quartet No. 8; Lady Macbeth of Mtsensk' },
+    { name: 'Benjamin Britten',          surname: 'Britten',       birth: 1913, death: 1976, era: 'modern',    hours: 25,  firstWork: 1922, lastWork: 1976, works: 'Peter Grimes; War Requiem; A Ceremony of Carols; Young Person\'s Guide to the Orchestra' },
+    { name: 'John Rutter',               surname: 'Rutter',        birth: 1945, death: null, era: 'modern',    hours: 18,  firstWork: 1963, lastWork: null, works: 'Requiem; Gloria; Magnificat; For the Beauty of the Earth; many Christmas carols' },
+  ];
+
+  // Layout
+  const START_YEAR = 1675;
+  const END_YEAR = 2030;
+  const PADDING_LEFT = 0;
+  const ROW_HEIGHT = 30;
+
+  const tl = document.getElementById('timeline');
+  const yearSpan = END_YEAR - START_YEAR;
+
+  // Era bands (background)
+  const eras = [
+    { name: 'Baroque',        start: 1675, end: 1750, color: 'var(--baroque)' },
+    { name: 'Classical',      start: 1750, end: 1820, color: 'var(--classical)' },
+    { name: 'Romantic',       start: 1820, end: 1880, color: 'var(--romantic)' },
+    { name: 'Late Romantic',  start: 1880, end: 1910, color: 'var(--late-rom)' },
+    { name: '20th Century',   start: 1910, end: 2030, color: 'var(--modern)' },
+  ];
+
+  function pct(year) {
+    return ((year - START_YEAR) / yearSpan) * 100;
+  }
+
+  // Build axis
+  const axis = document.createElement('div');
+  axis.className = 'axis';
+
+  // Era bands inside axis area extending into rows
+  // We add them as absolutely positioned overlays inside timeline (behind rows)
+  const bandsContainer = document.createElement('div');
+  bandsContainer.style.position = 'absolute';
+  bandsContainer.style.left = '0';
+  bandsContainer.style.right = '0';
+  bandsContainer.style.top = '0';
+  bandsContainer.style.bottom = '0';
+  bandsContainer.style.pointerEvents = 'none';
+  bandsContainer.style.zIndex = '0';
+
+  eras.forEach(era => {
+    const band = document.createElement('div');
+    band.className = 'era-band';
+    band.style.left = pct(era.start) + '%';
+    band.style.width = (pct(era.end) - pct(era.start)) + '%';
+    band.style.background = era.color;
+    bandsContainer.appendChild(band);
+
+    const label = document.createElement('div');
+    label.className = 'era-label';
+    label.textContent = era.name;
+    label.style.left = (pct(era.start) + (pct(era.end) - pct(era.start)) / 2) + '%';
+    label.style.transform = 'translateX(-50%)';
+    axis.appendChild(label);
+  });
+
+  // Year ticks every 25 years, major every 50
+  for (let y = 1700; y <= 2025; y += 25) {
+    const tick = document.createElement('div');
+    tick.className = 'axis-tick' + (y % 50 === 0 ? ' major' : '');
+    tick.style.left = pct(y) + '%';
+    axis.appendChild(tick);
+
+    if (y % 50 === 0) {
+      const lbl = document.createElement('div');
+      lbl.className = 'axis-label';
+      lbl.textContent = y;
+      lbl.style.left = pct(y) + '%';
+      axis.appendChild(lbl);
+    }
+  }
+
+  tl.appendChild(axis);
+
+  // Rows container
+  const rows = document.createElement('div');
+  rows.className = 'rows';
+  rows.style.position = 'relative';
+  rows.appendChild(bandsContainer);
+
+  // Bar height encodes total composed output (square-root scale to compress the range)
+  function barHeight(hours) {
+    const minH = 5;
+    const maxH = 22;
+    const maxHours = 110;
+    const t = Math.sqrt(Math.min(hours, maxHours) / maxHours);
+    return minH + (maxH - minH) * t;
+  }
+
+  composers.forEach((c, i) => {
+    const row = document.createElement('div');
+    row.className = 'row';
+
+    const isLiving = c.death === null;
+    const effectiveDeath = isLiving ? new Date().getFullYear() : c.death;
+    const isStillActive = c.lastWork === null;
+    const effectiveLastWork = isStillActive ? new Date().getFullYear() : c.lastWork;
+    const h = barHeight(c.hours);
+
+    // Lifespan bar (faded outer)
+    const lifeBar = document.createElement('div');
+    lifeBar.className = 'bar bar-life ' + c.era + (isLiving ? ' living' : '');
+    const lifeLeft = pct(c.birth);
+    const lifeWidth = pct(effectiveDeath) - pct(c.birth);
+    lifeBar.style.left = lifeLeft + '%';
+    lifeBar.style.width = lifeWidth + '%';
+    lifeBar.style.height = h + 'px';
+    lifeBar.style.animationDelay = (i * 35) + 'ms';
+    row.appendChild(lifeBar);
+
+    // Active composing bar (saturated inner)
+    const activeBar = document.createElement('div');
+    activeBar.className = 'bar bar-active ' + c.era + (isStillActive ? ' living' : '');
+    const activeLeft = pct(c.firstWork);
+    const activeWidth = pct(effectiveLastWork) - pct(c.firstWork);
+    activeBar.style.left = activeLeft + '%';
+    activeBar.style.width = activeWidth + '%';
+    activeBar.style.height = h + 'px';
+    activeBar.style.animationDelay = (i * 35 + 120) + 'ms';
+    row.appendChild(activeBar);
+
+    // Composer name — placement uses the lifespan bar geometry
+    const leftPct = lifeLeft;
+    const widthPct = lifeWidth;
+
+    // Composer name — placed cleverly: if bar is wide enough, inside; if at right edge, before the bar; otherwise after
+    const name = document.createElement('div');
+    name.className = 'composer-name';
+
+    // Decide placement
+    // Approximate pixel width: depends on viewport. Use percentage logic:
+    // If bar width > 14% of timeline → name inside bar (left-padded)
+    // Else if bar starts in right half (>50%) → name to the LEFT of bar
+    // Else → name to the RIGHT of bar
+    if (widthPct > 14) {
+      name.classList.add('inside');
+      name.style.left = `calc(${leftPct}% + 8px)`;
+      name.innerHTML = `<span class="surname">${c.surname}</span>`;
+    } else if (leftPct > 50) {
+      name.classList.add('outside-left');
+      name.style.right = `calc(${100 - leftPct}% + 8px)`;
+      name.innerHTML = `<span class="surname">${c.surname}</span>`;
+    } else {
+      name.classList.add('outside-right');
+      name.style.left = `calc(${leftPct + widthPct}% + 8px)`;
+      name.innerHTML = `<span class="surname">${c.surname}</span>`;
+    }
+    row.appendChild(name);
+
+    // Year label — birth year before bar (small, faint)
+    const years = document.createElement('div');
+    years.className = 'years';
+    years.style.right = `calc(${100 - leftPct}% + 6px)`;
+    years.textContent = c.birth;
+    row.appendChild(years);
+
+    // Death year after bar
+    const yearsRight = document.createElement('div');
+    yearsRight.className = 'years';
+    yearsRight.style.left = `calc(${leftPct + widthPct}% + 6px)`;
+    yearsRight.textContent = isLiving ? '' : c.death;
+    // Don't show death year if name is to the right (would collide)
+    if (name.classList.contains('outside-right')) {
+      yearsRight.style.display = 'none';
+    }
+    row.appendChild(yearsRight);
+
+    // Hide birth-year label if name is to the left of bar (would collide)
+    if (name.classList.contains('outside-left')) {
+      years.style.display = 'none';
+    }
+
+    // Hover tooltip via dataset
+    row.dataset.name = c.name;
+    row.dataset.birth = c.birth;
+    row.dataset.death = isLiving ? 'present' : c.death;
+    row.dataset.age = isLiving ? (effectiveDeath - c.birth) + ' (so far)' : (c.death - c.birth);
+    row.dataset.era = c.era;
+    row.dataset.works = c.works;
+    row.dataset.hours = c.hours;
+    row.dataset.firstWork = c.firstWork;
+    row.dataset.lastWork = isStillActive ? 'present' : c.lastWork;
+    row.dataset.silentYears = !isStillActive ? (effectiveDeath - c.lastWork) : 0;
+
+    rows.appendChild(row);
+  });
+
+  tl.appendChild(rows);
+
+  // ===== Connections =====
+  // from/to are indices into the composers array (0-based)
+  const connections = [
+    { from: 3,  to: 4,  year: 1785, posthumous: false, note: 'Haydn and Mozart became close friends in Vienna in the 1780s. Mozart dedicated his six "Haydn" Quartets to him; Haydn told Leopold Mozart his son was "the greatest composer known to me."' },
+    { from: 3,  to: 5,  year: 1793, posthumous: false, note: 'Beethoven studied counterpoint with Haydn in Vienna, 1792–94. The lessons were uneven (Beethoven secretly took extra lessons with Schenk), but the connection is direct.' },
+    { from: 4,  to: 5,  year: 1787, posthumous: false, note: 'A 16-year-old Beethoven traveled to Vienna in 1787 hoping to study with Mozart. He is said to have played for him; the visit was cut short when his mother fell ill.' },
+    { from: 5,  to: 6,  year: 1827, posthumous: false, note: 'Schubert idolized Beethoven and was a torchbearer at his funeral in March 1827. He died 20 months later and was buried near him at his own request.' },
+    { from: 1,  to: 8,  year: 1829, posthumous: true,  note: 'Mendelssohn led the famous 1829 Berlin revival of Bach\'s St. Matthew Passion — the first performance since Bach\'s death — beginning the modern Bach revival.' },
+    { from: 8,  to: 10, year: 1840, posthumous: false, note: 'Mendelssohn and Schumann were close friends and colleagues at the Leipzig Conservatory. Schumann was devastated by Mendelssohn\'s early death in 1847.' },
+    { from: 10, to: 14, year: 1853, posthumous: false, note: 'Schumann\'s 1853 essay "Neue Bahnen" hailed the 20-year-old Brahms as the heir to Beethoven, launching his career. Brahms remained close to the Schumann family for life.' },
+    { from: 11, to: 12, year: 1865, posthumous: false, note: 'Liszt championed Wagner\'s music for decades and conducted the premiere of Lohengrin (1850). Wagner married Liszt\'s daughter Cosima in 1870.' },
+    { from: 14, to: 16, year: 1875, posthumous: false, note: 'Brahms championed Dvořák, helping him win the Austrian State Stipend in 1875 and recommending him to his publisher Simrock — making Dvořák internationally known.' },
+    { from: 17, to: 23, year: 1899, posthumous: false, note: 'Ravel was Fauré\'s composition student at the Paris Conservatoire from 1897–1903. Fauré reported "a distinct gain in maturity, engaging wealth of imagination" and defended Ravel through the 1905 Prix de Rome scandal.' },
+    { from: 12, to: 18, year: 1882, posthumous: true,  note: 'Mahler was Wagner\'s most direct symphonic descendant, devoting much of his conducting career — at Vienna, the Met, and elsewhere — to Wagner\'s operas.' },
+    { from: 15, to: 22, year: 1892, posthumous: false, note: 'Tchaikovsky encouraged the young Rachmaninoff at the Moscow Conservatory and championed his student opera Aleko in 1892. Rachmaninoff was deeply shaken by his death the following year.' },
+    { from: 19, to: 23, year: 1905, posthumous: false, note: 'Debussy and Ravel were the defining French composers of their generation. They knew each other, premiered each other\'s works, and were eventually rivals in the press.' },
+    { from: 18, to: 26, year: 1925, posthumous: true,  note: 'Mahler\'s symphonic style — its scale, irony, and emotional extremity — was a defining influence on Shostakovich, especially in his later symphonies and string quartets.' },
+    { from: 26, to: 27, year: 1969, posthumous: false, note: 'Britten and Shostakovich became close friends after meeting in London in 1960. Britten dedicated The Prodigal Son (1968) to Shostakovich; Shostakovich dedicated his Symphony No. 14 (1969) back to Britten — they called it "our symphony" in correspondence.' },
+    { from: 27, to: 28, year: 1963, posthumous: false, note: 'Rutter sang as a Highgate School chorister on the famous 1963 Decca premiere recording of Britten\'s War Requiem under Britten\'s baton. He cites Britten and David Willcocks as the two main formative influences on his music.' },
+    { from: 17, to: 28, year: 1985, posthumous: true,  note: 'Fauré\'s Requiem is widely understood as the structural and emotional model for Rutter\'s own Requiem (1985) — both quiet, consoling, and notable for what they leave out (the Dies irae) as much as what they include.' },
+  ];
+
+  // Create SVG overlay
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('class', 'connections hidden');
+  svg.setAttribute('preserveAspectRatio', 'none');
+  rows.appendChild(svg);
+
+  function drawConnections() {
+    const rowsRect = rows.getBoundingClientRect();
+    const W = rowsRect.width;
+    const H = rowsRect.height;
+    if (W === 0) return;
+
+    svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+    svg.setAttribute('width', W);
+    svg.setAttribute('height', H);
+
+    // Clear
+    while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+    function xFromYear(year) {
+      return ((year - START_YEAR) / yearSpan) * W;
+    }
+    function yFromIndex(idx) {
+      return idx * ROW_HEIGHT + ROW_HEIGHT / 2;
+    }
+
+    connections.forEach((conn, i) => {
+      const x = xFromYear(conn.year);
+      const y1 = yFromIndex(conn.from);
+      const y2 = yFromIndex(conn.to);
+      const dy = Math.abs(y2 - y1);
+
+      // Curve bulges to the right; bulge scales with vertical distance
+      const bulge = Math.min(70, 12 + dy * 0.35);
+
+      const path = document.createElementNS(svgNS, 'path');
+      const d = `M ${x.toFixed(1)} ${y1} C ${(x + bulge).toFixed(1)} ${y1}, ${(x + bulge).toFixed(1)} ${y2}, ${x.toFixed(1)} ${y2}`;
+      path.setAttribute('d', d);
+      if (conn.posthumous) path.classList.add('dashed');
+      path.style.animationDelay = (1000 + i * 90) + 'ms';
+      path.dataset.note = conn.note;
+      path.dataset.from = composers[conn.from].name;
+      path.dataset.to = composers[conn.to].name;
+      path.dataset.year = conn.year;
+      path.dataset.fromIdx = conn.from;
+      path.dataset.toIdx = conn.to;
+
+      // Endpoint dots
+      const c1 = document.createElementNS(svgNS, 'circle');
+      c1.setAttribute('cx', x);
+      c1.setAttribute('cy', y1);
+      c1.setAttribute('r', 2.4);
+      c1.classList.add('endpoint');
+      c1.dataset.connIdx = i;
+
+      const c2 = document.createElementNS(svgNS, 'circle');
+      c2.setAttribute('cx', x);
+      c2.setAttribute('cy', y2);
+      c2.setAttribute('r', 2.4);
+      c2.classList.add('endpoint');
+      c2.dataset.connIdx = i;
+
+      svg.appendChild(path);
+      svg.appendChild(c1);
+      svg.appendChild(c2);
+
+      // Hover handling on the path
+      path.addEventListener('mousemove', (e) => {
+        path.classList.add('active');
+        c1.classList.add('active');
+        c2.classList.add('active');
+        tooltip.innerHTML = `
+          <div class="tt-name">${composers[conn.from].surname} → ${composers[conn.to].surname}</div>
+          <div class="tt-meta">${conn.year} · ${conn.posthumous ? 'Posthumous influence' : 'Direct contact'}</div>
+          <div class="tt-works">${conn.note}</div>
+        `;
+        tooltip.classList.add('show');
+        positionTooltip(e);
+      });
+      path.addEventListener('mouseleave', () => {
+        path.classList.remove('active');
+        c1.classList.remove('active');
+        c2.classList.remove('active');
+        tooltip.classList.remove('show');
+      });
+    });
+
+    // Trigger draw-in animation on first render
+    if (!svg.classList.contains('animate')) {
+      svg.classList.add('animate');
+    }
+  }
+
+  // Initial draw + redraw on resize
+  requestAnimationFrame(drawConnections);
+  let resizeTimer;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      svg.classList.remove('animate'); // skip animation on resize
+      drawConnections();
+    }, 80);
+  });
+
+  // Shared tooltip positioner
+  function positionTooltip(e) {
+    const rect = tooltip.getBoundingClientRect();
+    let x = e.clientX + 14;
+    let y = e.clientY + 14;
+    if (x + rect.width > window.innerWidth - 10) x = e.clientX - rect.width - 14;
+    if (y + rect.height > window.innerHeight - 10) y = e.clientY - rect.height - 14;
+    tooltip.style.left = x + 'px';
+    tooltip.style.top = y + 'px';
+  }
+
+  // Toggle handler for connections visibility
+  const toggleBtn = document.getElementById('toggleConnections');
+  toggleBtn.addEventListener('click', () => {
+    const isPressed = toggleBtn.getAttribute('aria-pressed') === 'true';
+    const next = !isPressed;
+    toggleBtn.setAttribute('aria-pressed', next);
+    svg.classList.toggle('hidden', !next);
+  });
+
+  // ===== End connections =====
+
+  // Tooltip behavior
+  const tooltip = document.getElementById('tooltip');
+  const eraNames = {
+    baroque: 'Baroque',
+    classical: 'Classical',
+    romantic: 'Romantic',
+    'late-rom': 'Late Romantic',
+    modern: '20th Century',
+  };
+
+  document.querySelectorAll('.row').forEach(row => {
+    row.addEventListener('mousemove', (e) => {
+      const age = row.dataset.age;
+      const silent = parseInt(row.dataset.silentYears, 10);
+      const silentNote = silent >= 5 ? ` <span class="tt-silence">— silent for ${silent} years</span>` : '';
+      tooltip.innerHTML = `
+        <div class="tt-name">${row.dataset.name}</div>
+        <div class="tt-meta">${row.dataset.birth} – ${row.dataset.death} · ${age} years · ${eraNames[row.dataset.era]}</div>
+        <div class="tt-stats">~${row.dataset.hours} hrs of music · Active ${row.dataset.firstWork}–${row.dataset.lastWork}${silentNote}</div>
+        <div class="tt-works">${row.dataset.works}</div>
+      `;
+      tooltip.classList.add('show');
+      const rect = tooltip.getBoundingClientRect();
+      let x = e.clientX + 14;
+      let y = e.clientY + 14;
+      if (x + rect.width > window.innerWidth - 10) x = e.clientX - rect.width - 14;
+      if (y + rect.height > window.innerHeight - 10) y = e.clientY - rect.height - 14;
+      tooltip.style.left = x + 'px';
+      tooltip.style.top = y + 'px';
+    });
+    row.addEventListener('mouseleave', () => {
+      tooltip.classList.remove('show');
+    });
+  });
+</script>
+</body>
+</html>

--- a/composers/index.html
+++ b/composers/index.html
@@ -560,6 +560,22 @@
     opacity: 0.95;
   }
 
+  /* Dark mode: legend SVG lines invisible on dark bg — use ink-soft */
+  html.dark .legend-item svg path {
+    stroke: var(--ink-soft);
+  }
+
+  /* Dark mode: tooltip bg flips to cream, so hardcoded light colors become invisible */
+  html.dark .tooltip .tt-stats {
+    color: rgba(26, 24, 20, 0.55);
+  }
+  html.dark .tooltip .tt-works {
+    color: rgba(26, 24, 20, 0.72);
+  }
+  html.dark .tooltip .tt-silence {
+    color: #7a3a10;
+  }
+
   /* 3. Era filter */
   .legend-item[data-era] {
     cursor: pointer;

--- a/composers/index.html
+++ b/composers/index.html
@@ -160,7 +160,7 @@
 
   .axis {
     position: relative;
-    height: 36px;
+    height: 46px;
     border-bottom: 1px solid var(--ink);
     margin-bottom: 4px;
   }
@@ -197,10 +197,10 @@
 
   .era-label {
     position: absolute;
-    top: 8px;
+    top: 6px;
     font-family: 'Cormorant Garamond', serif;
     font-style: italic;
-    font-size: 13px;
+    font-size: 12px;
     color: var(--ink-soft);
     letter-spacing: 0.06em;
     text-transform: uppercase;

--- a/index.html
+++ b/index.html
@@ -112,6 +112,12 @@
         <div class="app-desc">Tap colorful tiles to play synthesized silly sounds — horns, boings, farts, and more.</div>
       </a>
     </li>
+    <li>
+      <a href="composers/">
+        <div class="app-name">A Timeline of Composers</div>
+        <div class="app-desc">The lives of twenty-nine figures who shaped the symphonic and choral repertoire, plotted across three centuries with era bands and influence connections.</div>
+      </a>
+    </li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds `composers/index.html`: an interactive timeline of 29 classical composers spanning 1678–present
- Features era bands (Baroque → 20th Century), dual bars for lifespan vs. active composing years, hover tooltips with biographical details, and toggleable influence connection lines
- Linked from the main index page under "A Timeline of Composers"

## Test plan

- [ ] Open `composers/index.html` — timeline renders with all 29 rows and correct era colors
- [ ] Hover a composer row — tooltip shows name, dates, era, output hours, and notable works
- [ ] Toggle "Connections" button — influence arcs appear/disappear, hover on a path shows the connection note
- [ ] Resize the browser window — timeline scrolls horizontally, page layout stays intact
- [ ] Click the `composers/` link from `index.html` — navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)